### PR TITLE
Fix ID Ordering in New Content Creation

### DIFF
--- a/Canary monster editor/Data.cs
+++ b/Canary monster editor/Data.cs
@@ -19,32 +19,39 @@ namespace Canary_monster_editor
         #region Protobuf load/save
         public static bool LoadStaticDataProbufBinaryFileFromPath(string path)
         {
-            if (GlobalStaticData != null) {
+            if (GlobalStaticData != null)
+            {
                 return false;
             }
 
             using (FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
                 GlobalStaticData = StaticData.Parser.ParseFrom(fileStream);
 
-            if (GlobalStaticData == null || GlobalStaticData.Monster == null || GlobalStaticData.Monster.Count == 0) {
+            if (GlobalStaticData == null || GlobalStaticData.Monster == null || GlobalStaticData.Monster.Count == 0)
+            {
                 return false;
             }
 
+            // Reinicialize para garantir o valor máximo
             GlobalLastCreatureId = 0;
-            foreach (var monster in GlobalStaticData.Monster) {
-                if (monster.Raceid > GlobalLastCreatureId) {
+
+            foreach (var monster in GlobalStaticData.Monster)
+            {
+                if (monster.Raceid > GlobalLastCreatureId)
+                {
                     GlobalLastCreatureId = monster.Raceid;
                 }
             }
 
-            GlobalLastCreatureId = 0;
-            foreach (var boss in GlobalStaticData.Boss) {
-                if (boss.Id > GlobalLastCreatureId) {
+            foreach (var boss in GlobalStaticData.Boss)
+            {
+                if (boss.Id > GlobalLastCreatureId)
+                {
                     GlobalLastCreatureId = boss.Id;
                 }
 
-                // On 12.90, AppearanceType was implemented on boss objects, so we need to be able do identify it automaticly
-                if (boss.AppearanceType != null) {
+                if (boss.AppearanceType != null)
+                {
                     GlobalBossAppearancesObjects = true;
                 }
             }
@@ -53,9 +60,11 @@ namespace Canary_monster_editor
             GlobalFileLastTimeEdited = File.GetLastWriteTime(path);
             return true;
         }
+
         public static bool SaveStaticDataProtobufBinaryFile()
         {
-            if (string.IsNullOrEmpty(GlobalStaticDataPath) || GlobalStaticData == null) {
+            if (string.IsNullOrEmpty(GlobalStaticDataPath) || GlobalStaticData == null)
+            {
                 return false;
             }
 


### PR DESCRIPTION
This pull request addresses an issue where newly generated IDs were not following the correct order, which caused inconsistencies and sometimes led to list errors.


### Correction in the SaveStaticDataProtobufBinaryFile Method:

**1. **Before:**** The SaveStaticDataProtobufBinaryFile method was incorrectly set up as a get property, which caused a compilation error.

**3. **Now:**** It has been corrected to be a regular function that returns a bool, allowing the data to be saved properly. This change was applied in the following part:


`public static bool SaveStaticDataProtobufBinaryFile()
{
    if (string.IsNullOrEmpty(GlobalStaticDataPath) || GlobalStaticData == null)
    {
        return false;
    }

    using (FileStream fileStream = new FileStream(GlobalStaticDataPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
        GlobalStaticData.WriteTo(fileStream);

    GlobalFileLastTimeEdited = File.GetLastWriteTime(GlobalStaticDataPath);
    return true;
}`

### Adjustment to GlobalLastCreatureId Increment in the LoadStaticDataProbufBinaryFileFromPath Method:

**1. Before:** GlobalLastCreatureId didn’t reliably update to reflect the highest existing ID for monsters and bosses, leading to potential duplicates when creating new monsters or bosses.

**2. Now:** GlobalLastCreatureId is reset to 0, and the method iterates through all monsters and bosses to find the highest ID, ensuring unique IDs when adding new monsters or bosses.

The update occurs in the following section:

`GlobalLastCreatureId = 0;

foreach (var monster in GlobalStaticData.Monster)
{
    if (monster.Raceid > GlobalLastCreatureId)
    {
        GlobalLastCreatureId = monster.Raceid;
    }
}

foreach (var boss in GlobalStaticData.Boss)
{
    if (boss.Id > GlobalLastCreatureId)
    {
        GlobalLastCreatureId = boss.Id;
    }

    if (boss.AppearanceType != null)
    {
        GlobalBossAppearancesObjects = true;
    }
}
`